### PR TITLE
simutil: Suppress getopt warnings

### DIFF
--- a/tools/simutil/verilator/src/OptionsParser.cpp
+++ b/tools/simutil/verilator/src/OptionsParser.cpp
@@ -55,6 +55,9 @@ unsigned long long OptionsParser::str2ull(const std::string &str) {
 void OptionsParser::parse(int argc, char **argv) {
     int c;
 
+    // disable error handling of getopt
+    opterr = 0;
+
     while (1) {
         static struct option long_options[] = {
                 {"standalone", no_argument,       0, 'a'},


### PR DESCRIPTION
We don't want warnings for Verilator and other options.